### PR TITLE
feat: Switched to versioned kubernetes resources using hashicorp/kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following resources are used by this module:
 
 - [helm_release.cert-manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) (resource)
 - [helm_release.cert-manager-issuers](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) (resource)
-- [kubernetes_namespace.cert-manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) (resource)
+- [kubernetes_namespace_v1.cert-manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) (resource)
 
 ## Required Inputs
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ The following requirements are needed by this module:
 
 - helm (>= 3.0.0)
 
+- kubernetes (>= 2.7.0)
+
 ## Providers
 
 The following providers are used by this module:
 
 - helm (>= 3.0.0)
 
-- kubernetes
+- kubernetes (>= 2.7.0)
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_namespace" "cert-manager" {
+resource "kubernetes_namespace_v1" "cert-manager" {
   metadata {
     name = "cert-manager"
   }
@@ -10,7 +10,7 @@ resource "helm_release" "cert-manager" {
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
   version    = var.cert-manager-version
-  namespace  = kubernetes_namespace.cert-manager.metadata.0.name
+  namespace  = kubernetes_namespace_v1.cert-manager.metadata.0.name
 
   set = concat(
     [

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 3.0.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.7.0"
+    }
   }
 }


### PR DESCRIPTION
Moved to versioned kubernetes resources because old unversioned resources are deprecated with Kubernetes provider 3.x